### PR TITLE
Adapted GET path to allow using an endpoint URL with path prefix

### DIFF
--- a/lib/nominatim/reverse.rb
+++ b/lib/nominatim/reverse.rb
@@ -8,7 +8,7 @@ module Nominatim
 
     # Returns search result.
     def fetch
-      Nominatim::Place.new(get('/reverse', @criteria).body)
+      Nominatim::Place.new(get('reverse', @criteria).body)
     end
 
     # Latitude string to search for.

--- a/lib/nominatim/search.rb
+++ b/lib/nominatim/search.rb
@@ -9,7 +9,7 @@ module Nominatim
 
     # Iterates over the search results.
     def each(&block)
-      get('/search', @criteria).body.map! { |attrs| Nominatim::Place.new(attrs) }.each(&block)
+      get('search', @criteria).body.map! { |attrs| Nominatim::Place.new(attrs) }.each(&block)
     end
 
     # Query string to search for.


### PR DESCRIPTION
This modification allowed me to use an endpoint url with a path prefix, such as http://open.mapquestapi.com/nominatim/v1
