### PR TITLE
Add additional parameters for search api

### DIFF
--- a/lib/nominatim/search.rb
+++ b/lib/nominatim/search.rb
@@ -76,15 +76,6 @@ module Nominatim
       self
     end
 
-    # Street string to search for.
-    #
-    # @param street [String] Street string
-    # @return [Nominatim::Search]
-    def street(street)
-      @criteria[:street] = street
-      self
-    end
-
     # Limit search results to a specific country (or a list of countries).
     #
     # @param codes [Array<String>, String]

--- a/lib/nominatim/search.rb
+++ b/lib/nominatim/search.rb
@@ -22,6 +22,69 @@ module Nominatim
       self
     end
 
+    # Street string to search for.
+    #
+    # @param street [String] Street string
+    # @return [Nominatim::Search]
+    def street(street)
+      @criteria[:street] = street
+      self
+    end
+
+    # City string to search for.
+    #
+    # @param city [String] city string
+    # @return [Nominatim::Search]
+    def city(city)
+      @criteria[:city] = city
+      self
+    end
+
+    # County string to search for.
+    #
+    # @param county [String] county string
+    # @return [Nominatim::Search]
+    def county(county)
+      @criteria[:county] = county
+      self
+    end
+
+    # State string to search for.
+    #
+    # @param state [String] state string
+    # @return [Nominatim::Search]
+    def state(state)
+      @criteria[:state] = state
+      self
+    end
+
+    # Country string to search for.
+    #
+    # @param country [String] country string
+    # @return [Nominatim::Search]
+    def country(country)
+      @criteria[:country] = country
+      self
+    end
+
+    # Postal code string to search for.
+    #
+    # @param postalcode [String] postalcode string
+    # @return [Nominatim::Search]
+    def postalcode(postalcode)
+      @criteria[:postalcode] = postalcode
+      self
+    end
+
+    # Street string to search for.
+    #
+    # @param street [String] Street string
+    # @return [Nominatim::Search]
+    def street(street)
+      @criteria[:street] = street
+      self
+    end
+
     # Limit search results to a specific country (or a list of countries).
     #
     # @param codes [Array<String>, String]

--- a/spec/nominatim/search_spec.rb
+++ b/spec/nominatim/search_spec.rb
@@ -48,6 +48,48 @@ describe Nominatim::Search do
     end
   end
 
+  describe '#street' do
+    it 'adds a structured query criterion' do
+      search.street('Avenue')
+      search.criteria[:street].should eq 'Avenue'
+    end
+  end
+
+  describe '#city' do
+    it 'adds a structured query criterion' do
+      search.city('London')
+      search.criteria[:city].should eq 'London'
+    end
+  end
+
+  describe '#county' do
+    it 'adds a structured query criterion' do
+      search.county('Richmond County')
+      search.criteria[:county].should eq 'Richmond County'
+    end
+  end
+
+  describe '#state' do
+    it 'adds a structured query criterion' do
+      search.state('Georgia')
+      search.criteria[:state].should eq 'Georgia'
+    end
+  end
+
+  describe '#country' do
+    it 'adds a structured query criterion' do
+      search.country('Germany')
+      search.criteria[:country].should eq 'Germany'
+    end
+  end
+
+  describe '#postalcode' do
+    it 'adds a structured query criterion' do
+      search.postalcode('12345')
+      search.criteria[:postalcode].should eq '12345'
+    end
+  end
+
   describe '#country_codes' do
     it 'adds a country codes criterion' do
       search.country_codes('us')


### PR DESCRIPTION
http://wiki.openstreetmap.org/wiki/Nominatim

street=<housenumber> <streetname>
city=<city>
county=<county>
state=<state>
country=<country>
postalcode=<postalcode>
   (experimental) Alternative query string format for structured
requests.
   Structured requests are faster and require less server resources.
   DO NOT COMBINE WITH q=<query> PARAMETER.