### PR TITLE
Added 'key' param

### DIFF
--- a/lib/nominatim/client.rb
+++ b/lib/nominatim/client.rb
@@ -29,6 +29,7 @@ module Nominatim
 
       @connection.params[:format] = 'json'
       @connection.params[:email] = Nominatim.config.email if Nominatim.config.email
+      @connection.params[:key] = Nominatim.config.key if Nominatim.config.key
 
       @connection.headers[:user_agent] = Nominatim.config.user_agent
       @connection.headers[:"accept-language"] = Nominatim.config.accept_language

--- a/lib/nominatim/configuration.rb
+++ b/lib/nominatim/configuration.rb
@@ -3,6 +3,8 @@ module Nominatim
 
     DEFAULT_ENDPOINT = 'http://nominatim.openstreetmap.org'
 
+    DEFAULT_KEY = nil
+
     DEFAULT_USER_AGENT = "Nominatim Ruby Gem #{Nominatim::VERSION}"
 
     DEFAULT_EMAIL = nil
@@ -16,6 +18,7 @@ module Nominatim
 
     VALID_OPTIONS_KEYS = [
       :endpoint,
+      :key,
       :user_agent,
       :email,
       :accept_language,
@@ -37,6 +40,7 @@ module Nominatim
 
     def reset!
       self.endpoint         = DEFAULT_ENDPOINT
+      self.key              = DEFAULT_KEY
       self.user_agent       = DEFAULT_USER_AGENT
       self.email            = DEFAULT_EMAIL
       self.accept_language  = DEFAULT_LANGUAGE


### PR DESCRIPTION
Since 15th September 2015, the Nominatim Service
provided by MapQuest requires an AppKey.

See http://open.mapquestapi.com/nominatim/ for more
information.

Signed-off-by: Maximilian Güntner <maximilian.guentner@gmail.com>