### PR TITLE
Allow client to set the extratags flag in Nominatim and parse that as hash on Place.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Nominatim::Search has the following methods to craft structures requests:
 
 See http://wiki.openstreetmap.org/wiki/Nominatim#Parameters
 
+Nominatim::Search has the following flags to toggle result details:
+
+- address_details - Include a breakdown of the address into elements
+- extra_tags - Include additional information in the result if
+               available, e.g. wikipedia link, opening hours.
+
 ## Configuration
 
 ```ruby

--- a/lib/nominatim/place.rb
+++ b/lib/nominatim/place.rb
@@ -35,6 +35,13 @@ module Nominatim
       @address ||= Nominatim::Address.new(@attrs[:address]) if @attrs[:address]
     end
 
+    # Return extra Tags
+    #
+    # @return [Nominatim::Tags]
+    def extra_tags
+      @extra_tags ||= @attrs[:extratags]
+    end
+
     # Return a latitude
     #
     # @return [Float]

--- a/lib/nominatim/reverse.rb
+++ b/lib/nominatim/reverse.rb
@@ -40,5 +40,13 @@ module Nominatim
       self
     end
 
+    # Include extra tags has hash
+    #
+    # @param bool [true, false]
+    # @return [Nominatim::Reverse]
+    def extra_tags(bool)
+      @criteria[:extratags] = bool ? 1 : 0
+      self
+    end
   end
 end

--- a/lib/nominatim/search.rb
+++ b/lib/nominatim/search.rb
@@ -91,6 +91,15 @@ module Nominatim
       self
     end
 
+    # Include a breakdown of the address into elements.
+    #
+    # @param bool [true, false]
+    # @return [Nominatim::Search]
+    def extra_tags(bool)
+      @criteria[:extratags] = bool ? 1 : 0
+      self
+    end
+
     # Exclude given place ids from the search result.
     #
     # @param ids [Array<String>, String] Place ids

--- a/spec/fixtures/eiffeltower.json
+++ b/spec/fixtures/eiffeltower.json
@@ -1,0 +1,28 @@
+{
+  "class" : "tourism",
+  "lon" : "2.29449905431968",
+  "lat" : "48.8582602",
+  "boundingbox" : [
+    "48.8574753",
+    "48.8590465",
+    "2.2933084",
+    "2.2956897"
+  ],
+  "osm_id" : "5013364",
+  "osm_type" : "way",
+  "type" : "attraction",
+  "licence" : "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+  "icon" : "https://nominatim.openstreetmap.org/images/mapicons/poi_point_of_interest.p.20.png",
+  "display_name" : "Tour Eiffel, 5, Avenue Anatole France, Gros-Caillou, 7e, Paris, Île-de-France, France métropolitaine, 75007, France",
+  "extratags" : {
+    "wikipedia" : "fr:Tour Eiffel",
+    "website" : "http://toureiffel.paris",
+    "image" : "http://upload.wikimedia.org/wikipedia/commons/a/a8/Tour_Eiffel_Wikimedia_Commons.jpg",
+    "wikidata" : "Q243",
+    "fee" : "10-25€",
+    "wheelchair" : "yes",
+    "opening_hours" : "09:30-23:45; Jun 21-Sep 02: 09:00-00:45; Jul 14,Jul 15 off"
+  },
+  "place_id" : "69121935",
+  "importance" : 0.653772102971417
+}

--- a/spec/nominatim/place_spec.rb
+++ b/spec/nominatim/place_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'multi_json' # simulate Nominatim::Response::ParseJson Middleware
 
 describe Nominatim::Place do
   describe '#display_name' do
@@ -41,6 +42,35 @@ describe Nominatim::Place do
     it 'returns a Nominatim::Address when set' do
       place = Nominatim::Place.new(address: {county: 'Los Angeles', state: 'California', country: 'United States of America'})
       place.address.should be_a Nominatim::Address
+    end
+
+    it 'returns nil when not set' do
+      place = Nominatim::Place.new
+      place.address.should be_nil
+    end
+  end
+
+  describe '#extra_tags' do
+    before do
+      @eiffeltower = MultiJson.load(fixture("eiffeltower.json"), symbolize_keys: true)
+    end
+
+    it 'returns a Hash when set' do
+      place = Nominatim::Place.new(@eiffeltower)
+      place.extra_tags.should be_a Hash
+    end
+
+    it 'returns any key-value provided by Nominatim' do
+      place = Nominatim::Place.new(@eiffeltower)
+      place.extra_tags.keys.should eq %i[
+        wikipedia
+        website
+        image
+        wikidata
+        fee
+        wheelchair
+        opening_hours
+      ]
     end
 
     it 'returns nil when not set' do

--- a/spec/nominatim/reverse_spec.rb
+++ b/spec/nominatim/reverse_spec.rb
@@ -65,4 +65,17 @@ describe Nominatim::Reverse do
       reverse.criteria[:addressdetails].should eq 0
     end
   end
+
+  # See https://wiki.openstreetmap.org/wiki/Nominatim#Parameters_2
+  describe '#extra_tags' do
+    it 'adds an extra tags criterion set to 1' do
+      reverse.extra_tags(true)
+      reverse.criteria[:extratags].should eq 1
+    end
+
+    it 'sets 0 when set with false' do
+      reverse.extra_tags(false)
+      reverse.criteria[:extratags].should eq 0
+    end
+  end
 end

--- a/spec/nominatim/search_spec.rb
+++ b/spec/nominatim/search_spec.rb
@@ -163,6 +163,18 @@ describe Nominatim::Search do
     end
   end
 
+  describe '#extra_tags' do
+    it 'adds an extra tags criterion set to 1' do
+      search.extra_tags(true)
+      search.criteria[:extratags].should eq 1
+    end
+
+    it 'sets 0 when set with false' do
+      search.extra_tags(false)
+      search.criteria[:extratags].should eq 0
+    end
+  end
+
   describe '#exclude_place_ids' do
     it 'excludes given place ids' do
       search.exclude_place_ids('1')


### PR DESCRIPTION
This is configured similar to address_details.
But, because the result is highly changable, and keys are undocumented,
I chose to simply return the Hash and not, similar to Place#address a distinct
class with predefined attributes.

I need this to extract the opening_hours for a project.